### PR TITLE
Misc. improvements to container backup/restore

### DIFF
--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -273,7 +273,12 @@ const backgroundLogic = {
   },
 
   async backupIdentitiesState() {
-    const identities = await browser.contextualIdentities.query({});
+    const [identities, containerOrderStorage] = await Promise.all([
+      browser.contextualIdentities.query({}),
+      browser.storage.local.get([CONTAINER_ORDER_STORAGE_KEY])
+    ]);
+    const containerOrder =
+      containerOrderStorage && containerOrderStorage[CONTAINER_ORDER_STORAGE_KEY];
     return Promise.all(
       identities.map(async ({ cookieStoreId, color, icon, name }) => {
         const userContextId = this.getUserContextIdFromCookieStoreId(cookieStoreId);
@@ -285,10 +290,12 @@ const backgroundLogic = {
           assignManager.storageArea.getAssignedSites(userContextId)
         ]);
         const sites = Object.values(sitesByContainer).map(({ neverAsk, hostname }) => ({ neverAsk, hostname }));
+        const order = containerOrder && containerOrder[cookieStoreId];
         return ({
           color,
           icon,
           name,
+          order,
           isolated: isIsolated && true, // either `true` or `undefined`
           sites
         });
@@ -299,9 +306,10 @@ const backgroundLogic = {
   async restoreIdentitiesState(identities) {
     const oldIdentities = await browser.contextualIdentities.query({});
     const incomplete = [];
+    const containerOrder = {};
     let allSucceed = true;
     let index = -1;
-    const identitiesPromise = identities.map(async ({ color, icon, name, isolated, sites }) => {
+    const identitiesPromise = identities.map(async ({ color, icon, name, order, isolated, sites }) => {
       try {
         if (
           typeof color !== "string" || 
@@ -341,6 +349,8 @@ const backgroundLogic = {
         } catch (err) {
           incomplete.push(name); // site association damaged
         }
+        if (typeof order === "number")
+          containerOrder[identity.cookieStoreId] = order;
         if (make_new_identity)
           return identity;
         else
@@ -371,6 +381,12 @@ const backgroundLogic = {
           await this.deleteContainer(cookieStoreId, {removed: true});
         })
       );
+      if (Object.keys(containerOrder).length > 0)
+        await browser.storage.local.set({
+          [CONTAINER_ORDER_STORAGE_KEY]: containerOrder
+        });
+      else
+        await browser.storage.local.remove([CONTAINER_ORDER_STORAGE_KEY]);
     }
     return { created: created.length, removed: oldIdentities.length, incomplete };
   },

--- a/src/js/background/backgroundLogic.js
+++ b/src/js/background/backgroundLogic.js
@@ -297,9 +297,10 @@ const backgroundLogic = {
   },
 
   async restoreIdentitiesState(identities) {
-    const backup = await browser.contextualIdentities.query({});
+    const oldIdentities = await browser.contextualIdentities.query({});
     const incomplete = [];
     let allSucceed = true;
+    let index = -1;
     const identitiesPromise = identities.map(async ({ color, icon, name, isolated, sites }) => {
       try {
         if (
@@ -310,7 +311,19 @@ const backgroundLogic = {
           !Array.isArray((sites))
         )
           throw new Error("Corrupted container backup");
-        const identity = await browser.contextualIdentities.create({ color, icon, name });
+
+        let make_new_identity = false;
+        let identity = null;
+        index = oldIdentities.map(
+          ({ color, icon, name }) => JSON.stringify({ color, icon, name })
+        ).indexOf(JSON.stringify({ color, icon, name }));
+        if (index > -1) {
+          identity = oldIdentities.splice(index, 1)[0];
+        }
+        else {
+          make_new_identity = true;
+          identity = await browser.contextualIdentities.create({ color, icon, name });
+        }
         try {
           await identityState.storageArea.get(identity.cookieStoreId); // to create identity state
           const userContextId = this.getUserContextIdFromCookieStoreId(identity.cookieStoreId);
@@ -328,7 +341,10 @@ const backgroundLogic = {
         } catch (err) {
           incomplete.push(name); // site association damaged
         }
-        return identity;
+        if (make_new_identity)
+          return identity;
+        else
+          return null;
       } catch (err) {
         allSucceed = false;
         return null;
@@ -342,21 +358,21 @@ const backgroundLogic = {
           if (identityOrNull) {
             await identityState.storageArea.remove(identityOrNull.cookieStoreId);
             await browser.contextualIdentities.remove(identityOrNull.cookieStoreId);
+            await this.deleteContainer(identityOrNull.cookieStoreId, {removed: true});
           }
         })
       );
       throw new Error("Some containers couldn't be created");
+    } else { // Importation succeed, remove old identities
+      await Promise.all(
+        oldIdentities.map(async ({cookieStoreId}) => {
+          await identityState.storageArea.remove(cookieStoreId);
+          await browser.contextualIdentities.remove(cookieStoreId);
+          await this.deleteContainer(cookieStoreId, {removed: true});
+        })
+      );
     }
-
-    // Importation succeed, remove old identities
-    await Promise.all(
-      backup.map(async (identity) => {
-        await identityState.storageArea.remove(identity.cookieStoreId);
-        await browser.contextualIdentities.remove(identity.cookieStoreId);
-      })
-    );
-
-    return { created: created.length, incomplete };
+    return { created: created.length, removed: oldIdentities.length, incomplete };
   },
 
   async queryIdentitiesState(windowId) {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -81,7 +81,7 @@ async function restoreContainers(event) {
     reader.onloadend = async () => {
       try {
         const identitiesState = JSON.parse(reader.result);
-        const { created: restoredCount, incomplete } = await browser.runtime.sendMessage({
+        const { created: restoredCount, removed: removedCount, incomplete } = await browser.runtime.sendMessage({
           method: "restoreIdentitiesState",
           identities: identitiesState
         });
@@ -90,6 +90,10 @@ async function restoreContainers(event) {
           restoreResult.style.color = "green";
         } else {
           restoreResult.textContent = browser.i18n.getMessage("containersPartiallyRestored", [String(restoredCount), String(incomplete.join(", "))]);
+          restoreResult.style.color = "orange";
+        }
+        if (removedCount) {
+          restoreResult.textContent += browser.i18n.getMessage("containersRemoved", [String(removedCount)]);
           restoreResult.style.color = "orange";
         }
       } catch (err) {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -60,7 +60,9 @@ async function backupContainers() {
     const content = JSON.stringify(
       await browser.runtime.sendMessage({
         method: "backupIdentitiesState"
-      })
+      }),
+      null,
+      2
     );
     backupLink.href = `data:application/json;base64,${btoa(content)}`;
     backupLink.download = `containers-backup-${(new Date()).toISOString()}.json`;

--- a/src/js/proxified-containers.js
+++ b/src/js/proxified-containers.js
@@ -65,6 +65,8 @@ proxifiedContainers = {
   async delete(cookieStoreId) {
     // Assumes proxy is a properly formatted object
     const proxifiedContainersStore = await proxifiedContainers.retrieveAll();
+    if (proxifiedContainersStore === null)
+      return null;
     const index = proxifiedContainersStore.findIndex(i => i.cookieStoreId === cookieStoreId);
     if (index !== -1) {
       proxifiedContainersStore.splice(index, 1);


### PR DESCRIPTION
Hi, I have a few improvements to container backups you might be interested in. I know the merge is taking a long time but I've found these useful so I'm suggesting them anyway.

- When restoring containers, only delete containers that aren't present in the save file. This means that a save file can be restored from multiple times without losing data or rearranging container ids. Containers must share a `{ color, icon, name }` to match.
- Pretty-print the container backup JSON
- Save container ordering

The associated localization branch is at: https://github.com/aaronkollasch/multi-account-containers-l10n/tree/patch-1